### PR TITLE
SHEET: Move cell creation into counting expression

### DIFF
--- a/sheet/index.html
+++ b/sheet/index.html
@@ -1,6 +1,6 @@
-<table id=t><script>for(e=[a=0];6>a;a++)for(b=t.insertRow(c=-1);d="@ABCDE"[++c];)b.insertCell(-1).innerHTML=a*c?e.push(I=d+a)&&"<input id="+I+" onfocus=this.value=l."+I+"||'' onblur=l."+I+"=this.value;A()>":a||d;function A(X){e.forEach(function(i){X&&Object.defineProperty(e,i,{get:function(){with(b=(l=localStorage)[i]||'',e)return"="!=b[0]?b!=+b?b:b&&+b:eval(b.substr(1))}});try{eval(i).value=e[i]}catch(x){}})}A(1)</script>
+<table id=t><script>for(e=[a=0];6>a;a++)for(b=t.insertRow(c=-1);d="@ABCDE"[++c];b.insertCell(-1).innerHTML=a*c?e.push(I=d+a)&&"<input id="+I+" onfocus=this.value=l."+I+"||'' onblur=l."+I+"=this.value;A()>":a||d)function A(X){e.forEach(function(i){X&&Object.defineProperty(e,i,{get:function(){with(b=(l=localStorage)[i]||'',e)return"="!=b[0]?b!=+b?b:b&&+b:eval(b.substr(1))}});try{eval(i).value=e[i]}catch(x){}})}A(1)</script>
 
-<!-- 426 bytes -->
+<!-- 425 bytes -->
 
 
 
@@ -35,13 +35,13 @@ Source:
 
 <pre>
 &lt;table id=t>&lt;script>for(e=[a=0];6>a;a++)for(b=t.insertRow
-(c=-1);d="@ABCDE"[++c];)b.insertCell(-1).innerHTML=a*c?e.
-push(I=d+a)&&"&lt;input id="+I+" onfocus=this.value=l."+I+"|
-|'' onblur=l."+I+"=this.value;A()>":a||d;function A(X){e.
-forEach(function(i){X&&Object.defineProperty(e,i,{get:fun
-ction(){with(b=(l=localStorage)[i]||'',e)return"="!=b[0]?
-b!=+b?b:b&&+b:eval(b.substr(1))}});try{eval(i).value=e[i]
-}catch(x){}})}A(1)&lt;/script> // 426 bytes
+(c=-1);d="@ABCDE"[++c];b.insertCell(-1).innerHTML=a*c?e.p
+ush(I=d+a)&&"&lt;input id="+I+" onfocus=this.value=l."+I+"||
+'' onblur=l."+I+"=this.value;A()>":a||d)function A(X){e.f
+orEach(function(i){X&&Object.defineProperty(e,i,{get:func
+tion(){with(b=(l=localStorage)[i]||'',e)return"="!=b[0]?b
+!=+b?b:b&&+b:eval(b.substr(1))}});try{eval(i).value=e[i]}
+catch(x){}})}A(1)&lt;/script> // 425 bytes
 </pre>
 
 <script>


### PR DESCRIPTION
As `b.insertCell()...` in an expression it can be safely moved into for
loop's counting expression section.

function A becomes a new `for` body and once it's a FunctionDeclaration,
it is a block and therefore don't need a semicolon after.

Counter-intuitive moment: despite the fact this FD is located inside
loop body, it is hoisted and runs only once instead of being evaluated
at each loop step.
