### PR TITLE
Had it down to 303 until I found a bug...

### DIFF
--- a/sheet/index.html
+++ b/sheet/index.html
@@ -1,8 +1,6 @@
-<table id=t><script>function A(){for(a=h='';9>a;a++)for(h+="<tr>",c=0;d=" ABCDE"[c];)with(t)h+="<td>"+(c++?a?t[d+=a]=t[d]?top[d][V='value']="="!=(b=l[d]||'')[0]?b!=+b?b:b&&+b:eval(d+b):'<input id=D onfocus=D[V]=[l.D] onblur=A(l.D=D[V])>'.replace(/D/g,d):d:a)}A(A(l=localStorage),t.innerHTML=h)</script>
+<table id=t><script>function A(d){if(d)return"="!=(b=l[d]||'')[0]?b!=+b?b:b&&+b:eval(V+b.replace(/[A-E]\d/g,"A('$&')"));for(a=h='';9>a;a++)for(h+="<tr>",c=0;d=" ABCDE"[c];)h+="<td>"+(c++?a?A[d+=a]?top[d][V='value']=A(d):'<input id=D onfocus=D[V]=[l.D] onblur=l.D=D[V];A()>'.replace(/D/g,d,A[d]=A):d:a)}A(A(),l=localStorage,t.innerHTML=h)</script>
 
-<!-- 303 bytes -->
-
-
+<!-- 347 bytes -->
 
 
 
@@ -10,8 +8,10 @@
 
 
 
-<title>A Spreadsheet in 303 bytes of JavaScript</title>
-<b>A Spreadsheet in 303 bytes of JavaScript</b>
+
+
+<title>A Spreadsheet in 347 bytes of JavaScript</title>
+<b>A Spreadsheet in 347 bytes of JavaScript</b>
 
 <p>
   Main logic by <a href="http://ondras.zarovi.cz/">Ondras Zarovi</a> (<a href="http://jsfiddle.net/ondras/hYfN3/">source</a>),
@@ -30,10 +30,12 @@ Features:
 Source:
 
 <pre>
-&lt;table id=t>&lt;script>function A(){for(a=h='';9>a;a++)for(h+="&lt;tr>",c=0;d=
-" ABCDE"[c];)with(t)h+="&lt;td>"+(c++?a?t[d+=a]=t[d]?top[d][V='value']="="!
-=(b=l[d]||'')[0]?b!=+b?b:b&&+b:eval(d+b):'&lt;input id=D onfocus=D[V]=[l.D]
- onblur=A(l.D=D[V])>'.replace(/D/g,d):d:a)}A(A(l=localStorage),t.innerHTML=h)&lt;/script>// 303
+&lt;table id=t>&lt;script>
+function A(d){if(d)return"="!=(b=l[d]||'')[0]?b!=+b?b:b&&+b:eval(V+b.replace(
+/[A-E]\d/g,"A('$&')"));for(a=h='';9>a;a++)for(h+="&lt;tr>",c=0;d=" ABCDE"[c];)
+h+="&lt;td>"+(c++?a?A[d+=a]?top[d][V='value']=A(d):'&lt;input id=D onfocus=D[V]
+=[l.D] onblur=l.D=D[V];A()>'.replace(/D/g,d,A[d]=A):d:a)}A(A(),l=localStorage,
+t.innerHTML=h)&lt;/script>// 347
 </pre>
 
 <script>


### PR DESCRIPTION
To see the bug - look in master or my older commit 31fac9a and try creating a formula chain in reverse reading order such as:

A1: =A2
A2: =A3
A3: =A4
...

Stashing the calculated value in t then reading using "with(t)" means that we only resolve the first level of a chain of formula calls if they are not all fully resolved in left to right, top to bottom reading order. This may be an acceptable limitation, but I feel most spreadsheets users would consider it broken. 

I went back to treating cell values as function calls based on some of my previous commits because it allows for formula chains as large as the stack. We could instead brute force it by adding an outer for loop that iterates the inner loops in A() by the total number of cells (9*5) and we could probably even get away with fewer iterations and still fool most users but it just felt wrong :-P
